### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/valtech/OptimizelyTestContainers/security/code-scanning/1](https://github.com/valtech/OptimizelyTestContainers/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow performs build and test operations, it likely only needs read access to the repository contents. We will add the following permissions block at the root of the workflow:

```yaml
permissions:
  contents: read
```

This ensures that the workflow has read-only access to the repository contents, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
